### PR TITLE
Remove leaking ssl session

### DIFF
--- a/src/ngx_ssl_ja3.c
+++ b/src/ngx_ssl_ja3.c
@@ -299,7 +299,6 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
 int
 ngx_ssl_ja3(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja3_t *ja3) {
 
-    ngx_ssl_session_t             *ssl_session;
     SSL                           *ssl;
     unsigned short                *ciphers_out = NULL;
     int                           *curves_out = NULL;
@@ -312,11 +311,6 @@ ngx_ssl_ja3(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja3_t *ja3) {
     }
 
     if (! c->ssl->handshaked) {
-        return NGX_DECLINED;
-    }
-
-    ssl_session = ngx_ssl_get_session(c);
-    if (! ssl_session) {
         return NGX_DECLINED;
     }
 


### PR DESCRIPTION
It looks like `ssl_session` is not used, so I removed it. Memory leak disappeared.

Fixes #17 