### PR TITLE
Prevent requirement of C99 mode

### DIFF
--- a/patches/nginx.1.17.1.ssl.extensions.patch
+++ b/patches/nginx.1.17.1.ssl.extensions.patch
@@ -1,7 +1,7 @@
 diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
 --- a/src/event/ngx_event_openssl.c	Thu May 23 16:49:22 2019 +0300
 +++ b/src/event/ngx_event_openssl.c	Sat Jun 01 14:53:52 2019 +0000
-@@ -1588,6 +1588,107 @@
+@@ -1588,6 +1588,108 @@
      return NGX_OK;
  }
  
@@ -14,6 +14,7 @@ diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
 +    unsigned short                *ciphers_out = NULL;
 +    int                           *curves_out = NULL;
 +    int                           *point_formats_out = NULL;
++    size_t                         i;
 +    size_t                         len = 0;
 +    SSL                           *s = NULL;
 +
@@ -42,7 +43,7 @@ diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
 +            len = c->ssl->curves_sz * sizeof(unsigned short);
 +            c->ssl->curves = ngx_pnalloc(c->pool, len);
 +            if (c->ssl->curves != NULL) {
-+                for (size_t i = 0; i < c->ssl->curves_sz; i++) {
++                for (i = 0; i < c->ssl->curves_sz; i++) {
 +                     c->ssl->curves[i] = curves_out[i];
 +                }
 +            }

--- a/src/ngx_ssl_ja3.c
+++ b/src/ngx_ssl_ja3.c
@@ -50,7 +50,8 @@ static const unsigned short GREASE[] = {
 static int
 ngx_ssl_ja3_is_ext_greased(int id)
 {
-    for (size_t i = 0; i < (sizeof(GREASE) / sizeof(GREASE[0])); ++i) {
+    size_t i;
+    for (i = 0; i < (sizeof(GREASE) / sizeof(GREASE[0])); ++i) {
         if (id == GREASE[i]) {
             return 1;
         }
@@ -95,9 +96,10 @@ static const int nid_list[] = {
 static unsigned short
 ngx_ssl_ja3_nid_to_cid(int nid)
 {
+    unsigned char i;
     unsigned char sz = (sizeof(nid_list) / sizeof(nid_list[0]));
 
-    for (unsigned char i = 0; i < sz; i++) {
+    for (i = 0; i < sz; i++) {
         if (nid == nid_list[i]) {
             return i+1;
         }
@@ -124,6 +126,7 @@ ngx_ssj_ja3_num_digits(int n)
 static void
 ngx_ssl_ja3_detail_print(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3)
 {
+    size_t i;
     /* Version */
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT,
                    pool->log, 0, "ssl_ja3: Version:  %d\n", ja3->version);
@@ -133,7 +136,7 @@ ngx_ssl_ja3_detail_print(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3)
                    pool->log, 0, "ssl_ja3: ciphers: length: %d\n",
                    ja3->ciphers_sz);
 
-    for (size_t i = 0; i < ja3->ciphers_sz; ++i) {
+    for (i = 0; i < ja3->ciphers_sz; ++i) {
         ngx_log_debug2(NGX_LOG_DEBUG_EVENT,
                        pool->log, 0, "ssl_ja3: |    cipher: 0x%04uxD -> %d",
                        ja3->ciphers[i],
@@ -146,7 +149,7 @@ ngx_ssl_ja3_detail_print(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3)
                    pool->log, 0, "ssl_ja3: extensions: length: %d\n",
                    ja3->extensions_sz);
 
-    for (size_t i = 0; i < ja3->extensions_sz; ++i) {
+    for (i = 0; i < ja3->extensions_sz; ++i) {
         ngx_log_debug2(NGX_LOG_DEBUG_EVENT,
                        pool->log, 0, "ssl_ja3: |    extension: 0x%04uxD -> %d",
                        ja3->extensions[i],
@@ -159,7 +162,7 @@ ngx_ssl_ja3_detail_print(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3)
                    pool->log, 0, "ssl_ja3: curves: length: %d\n",
                    ja3->curves_sz);
 
-    for (size_t i = 0; i < ja3->curves_sz; ++i) {
+    for (i = 0; i < ja3->curves_sz; ++i) {
         ngx_log_debug2(NGX_LOG_DEBUG_EVENT,
                        pool->log, 0, "ssl_ja3: |    curves: 0x%04uxD -> %d",
                        ja3->curves[i],
@@ -171,7 +174,7 @@ ngx_ssl_ja3_detail_print(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3)
     ngx_log_debug1(NGX_LOG_DEBUG_EVENT,
                    pool->log, 0, "ssl_ja3: formats: length: %d\n",
                    ja3->point_formats_sz);
-    for (size_t i = 0; i < ja3->point_formats_sz; ++i) {
+    for (i = 0; i < ja3->point_formats_sz; ++i) {
         ngx_log_debug1(NGX_LOG_DEBUG_EVENT,
                        pool->log, 0, "ssl_ja3: |    format: %d",
                        ja3->point_formats[i]
@@ -184,6 +187,7 @@ ngx_ssl_ja3_detail_print(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3)
 void
 ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
 {
+    size_t                    i;
     size_t                    len = 0, cur = 0;
 
     if (pool == NULL || ja3 == NULL || out == NULL) {
@@ -194,7 +198,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     ++len;                                                  /* ',' separator */
 
     if (ja3->ciphers_sz) {
-        for (size_t i = 0; i < ja3->ciphers_sz; ++i) {
+        for (i = 0; i < ja3->ciphers_sz; ++i) {
             len += ngx_ssj_ja3_num_digits(ja3->ciphers[i]); /* cipher [i] */
         }
         len += (ja3->ciphers_sz - 1);                       /* '-' separators */
@@ -202,7 +206,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     ++len;                                                  /* ',' separator */
 
     if (ja3->extensions_sz) {
-        for (size_t i = 0; i < ja3->extensions_sz; ++i) {
+        for (i = 0; i < ja3->extensions_sz; ++i) {
             len += ngx_ssj_ja3_num_digits(ja3->extensions[i]); /* ext [i] */
         }
         len += (ja3->extensions_sz - 1);                   /* '-' separators */
@@ -210,7 +214,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     ++len;                                                  /* ',' separator */
 
     if (ja3->curves_sz) {
-        for (size_t i = 0; i < ja3->curves_sz; ++i) {
+        for (i = 0; i < ja3->curves_sz; ++i) {
             len += ngx_ssj_ja3_num_digits(ja3->curves[i]); /* curves [i] */
         }
         len += (ja3->curves_sz - 1);                       /* '-' separators */
@@ -218,7 +222,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     ++len;                                                  /* ',' separator */
 
     if (ja3->point_formats_sz) {
-        for (size_t i = 0; i < ja3->point_formats_sz; ++i) {
+        for (i = 0; i < ja3->point_formats_sz; ++i) {
             len += ngx_ssj_ja3_num_digits(ja3->point_formats[i]); /* fmt [i] */
         }
         len += (ja3->point_formats_sz - 1);                 /* '-' separators */
@@ -232,7 +236,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     cur += len;
 
     if (ja3->ciphers_sz) {
-        for (size_t i = 0; i < ja3->ciphers_sz; ++i) {
+        for (i = 0; i < ja3->ciphers_sz; ++i) {
             if (i > 0) {
                 ngx_snprintf(out->data + (cur++), 1, "-");
             }
@@ -244,7 +248,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     ngx_snprintf(out->data + (cur++), 1, ",");
 
     if (ja3->extensions_sz) {
-        for (size_t i = 0; i < ja3->extensions_sz; i++) {
+        for (i = 0; i < ja3->extensions_sz; i++) {
             if (i > 0) {
                 ngx_snprintf(out->data + (cur++), 1, "-");
             }
@@ -256,7 +260,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     ngx_snprintf(out->data + (cur++), 1, ",");
 
     if (ja3->curves_sz) {
-        for (size_t i = 0; i < ja3->curves_sz; i++) {
+        for (i = 0; i < ja3->curves_sz; i++) {
             if (i > 0) {
                 ngx_snprintf(out->data + (cur++), 1, "-");
             }
@@ -268,7 +272,7 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     ngx_snprintf(out->data + (cur++), 1, ",");
 
     if (ja3->point_formats_sz) {
-        for (size_t i = 0; i < ja3->point_formats_sz; i++) {
+        for (i = 0; i < ja3->point_formats_sz; i++) {
             if (i > 0) {
                 ngx_snprintf(out->data + (cur++), 1, "-");
             }
@@ -296,6 +300,7 @@ int
 ngx_ssl_ja3(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja3_t *ja3) {
 
     SSL                           *ssl;
+    size_t                         i;
     size_t                         len = 0;
     unsigned short                 us = 0;
 
@@ -326,7 +331,7 @@ ngx_ssl_ja3(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja3_t *ja3) {
             return NGX_DECLINED;
         }
         /* Filter out GREASE extensions */
-        for (size_t i = 0; i < c->ssl->ciphers_sz; ++i) {
+        for (i = 0; i < c->ssl->ciphers_sz; ++i) {
             us = ntohs(c->ssl->ciphers[i]);
             if (! ngx_ssl_ja3_is_ext_greased(us)) {
                 ja3->ciphers[ja3->ciphers_sz++] = us;
@@ -343,7 +348,7 @@ ngx_ssl_ja3(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja3_t *ja3) {
         if (ja3->extensions == NULL) {
             return NGX_DECLINED;
         }
-        for (size_t i = 0; i < c->ssl->extensions_size; ++i) {
+        for (i = 0; i < c->ssl->extensions_size; ++i) {
             if (! ngx_ssl_ja3_is_ext_greased(c->ssl->extensions[i])) {
                 ja3->extensions[ja3->extensions_sz++] = c->ssl->extensions[i];
             }
@@ -359,7 +364,7 @@ ngx_ssl_ja3(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja3_t *ja3) {
         if (ja3->curves == NULL) {
             return NGX_DECLINED;
         }
-        for (size_t i = 0; i < c->ssl->curves_sz; i++) {
+        for (i = 0; i < c->ssl->curves_sz; i++) {
             us = ntohs(c->ssl->curves[i]);
             if (! ngx_ssl_ja3_is_ext_greased(us)) {
                 ja3->curves[ja3->curves_sz++] = ngx_ssl_ja3_nid_to_cid(c->ssl->curves[i]);


### PR DESCRIPTION
After aplying this patch nginx can't be build because:
```
src/event/ngx_event_openssl.c: In function 'ngx_SSL_client_features':
src/event/ngx_event_openssl.c:1628:17: error: 'for' loop initial declarations are only allowed in C99 mode
src/event/ngx_event_openssl.c:1628:17: note: use option -std=c99 or
-std=gnu99 to compile your code
```

This simple changes fixed it