### PR TITLE
nginx-ssl-ja3: fix python installation in docker image

### DIFF
--- a/docker/debian-nginx-ssl-ja3/Dockerfile
+++ b/docker/debian-nginx-ssl-ja3/Dockerfile
@@ -40,7 +40,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
     mercurial \
     ngrep \
     procps \
-    python \
+    python3 \
     telnet \
     tcpflow \
     valgrind \


### PR DESCRIPTION
Fixes #26 