### PR TITLE
Fix potential memory leak

### DIFF
--- a/patches/nginx.1.14.0.ssl.extensions.patch
+++ b/patches/nginx.1.14.0.ssl.extensions.patch
@@ -1,6 +1,6 @@
 diff -Naurp nginx-1.14.0.orig/src/event/ngx_event_openssl.c nginx-1.14.0/src/event/ngx_event_openssl.c
---- nginx-1.14.0.orig/src/event/ngx_event_openssl.c	2018-04-17 18:22:36.000000000 +0300
-+++ nginx-1.14.0/src/event/ngx_event_openssl.c	2020-10-26 21:08:09.110961786 +0300
+--- nginx-1.14.0.orig/src/event/ngx_event_openssl.c	2022-07-26 12:37:49.136566490 +0430
++++ nginx-1.14.0/src/event/ngx_event_openssl.c	2022-07-26 12:38:20.926566041 +0430
 @@ -1220,6 +1220,107 @@ ngx_ssl_set_session(ngx_connection_t *c,
      return NGX_OK;
  }
@@ -97,8 +97,8 @@ diff -Naurp nginx-1.14.0.orig/src/event/ngx_event_openssl.c nginx-1.14.0/src/eve
 +            if (c->ssl->extensions != NULL) {
 +                c->ssl->extensions_size = ext_len;
 +                ngx_memcpy(c->ssl->extensions, ext_out, sizeof(int) * ext_len);
-+                OPENSSL_free(ext_out);
 +            }
++            OPENSSL_free(ext_out);
 +        }
 +    }
 +
@@ -134,8 +134,8 @@ diff -Naurp nginx-1.14.0.orig/src/event/ngx_event_openssl.c nginx-1.14.0/src/eve
          c->send = ngx_ssl_write;
          c->recv_chain = ngx_ssl_recv_chain;
 diff -Naurp nginx-1.14.0.orig/src/event/ngx_event_openssl.h nginx-1.14.0/src/event/ngx_event_openssl.h
---- nginx-1.14.0.orig/src/event/ngx_event_openssl.h	2018-04-17 18:22:36.000000000 +0300
-+++ nginx-1.14.0/src/event/ngx_event_openssl.h	2020-10-26 21:10:34.943067201 +0300
+--- nginx-1.14.0.orig/src/event/ngx_event_openssl.h	2022-07-26 12:37:49.136566490 +0430
++++ nginx-1.14.0/src/event/ngx_event_openssl.h	2022-07-26 12:37:56.666566384 +0430
 @@ -86,6 +86,23 @@ struct ngx_ssl_connection_s {
      unsigned                    no_wait_shutdown:1;
      unsigned                    no_send_shutdown:1;

--- a/patches/nginx.1.17.1.ssl.extensions.patch
+++ b/patches/nginx.1.17.1.ssl.extensions.patch
@@ -1,7 +1,7 @@
-diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
---- a/src/event/ngx_event_openssl.c	Thu May 23 16:49:22 2019 +0300
-+++ b/src/event/ngx_event_openssl.c	Sat Jun 01 14:53:52 2019 +0000
-@@ -1588,6 +1588,108 @@
+diff -Naurp nginx-1.17.1.orig/src/event/ngx_event_openssl.c nginx-1.17.1/src/event/ngx_event_openssl.c
+--- nginx-1.17.1.orig/src/event/ngx_event_openssl.c	2022-07-26 12:21:34.726580042 +0430
++++ nginx-1.17.1/src/event/ngx_event_openssl.c	2022-07-26 12:24:59.656577206 +0430
+@@ -1588,6 +1588,108 @@ ngx_ssl_set_session(ngx_connection_t *c,
      return NGX_OK;
  }
  
@@ -98,8 +98,8 @@ diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
 +            if (c->ssl->extensions != NULL) {
 +                c->ssl->extensions_size = ext_len;
 +                ngx_memcpy(c->ssl->extensions, ext_out, sizeof(int) * ext_len);
-+                OPENSSL_free(ext_out);
 +            }
++            OPENSSL_free(ext_out);
 +        }
 +    }
 +
@@ -110,7 +110,7 @@ diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
  
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
-@@ -1603,6 +1704,10 @@
+@@ -1603,6 +1705,10 @@ ngx_ssl_handshake(ngx_connection_t *c)
  
      ngx_ssl_clear_error(c->log);
  
@@ -121,7 +121,7 @@ diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
      n = SSL_do_handshake(c->ssl->connection);
  
      ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
-@@ -1623,6 +1728,12 @@
+@@ -1623,6 +1729,12 @@ ngx_ssl_handshake(ngx_connection_t *c)
  
          c->ssl->handshaked = 1;
  
@@ -134,10 +134,10 @@ diff -r d964b0aee8e7 src/event/ngx_event_openssl.c
          c->recv = ngx_ssl_recv;
          c->send = ngx_ssl_write;
          c->recv_chain = ngx_ssl_recv_chain;
-diff -r d964b0aee8e7 src/event/ngx_event_openssl.h
---- a/src/event/ngx_event_openssl.h	Thu May 23 16:49:22 2019 +0300
-+++ b/src/event/ngx_event_openssl.h	Sat Jun 01 14:53:52 2019 +0000
-@@ -99,6 +99,23 @@
+diff -Naurp nginx-1.17.1.orig/src/event/ngx_event_openssl.h nginx-1.17.1/src/event/ngx_event_openssl.h
+--- nginx-1.17.1.orig/src/event/ngx_event_openssl.h	2022-07-26 12:21:34.726580042 +0430
++++ nginx-1.17.1/src/event/ngx_event_openssl.h	2022-07-26 12:23:43.489911600 +0430
+@@ -99,6 +99,23 @@ struct ngx_ssl_connection_s {
      unsigned                    in_early:1;
      unsigned                    early_preread:1;
      unsigned                    write_blocked:1;


### PR DESCRIPTION
`OPENSSL_free` MUST be called if `SSL_client_hello_get1_extensions_present` is successful. so we should release the allocated memory anyway, regardless of `ngx_palloc` success or failure.

[BTW `nginx.1.23.0.ssl.extensions.patch` has also the same problem but I couldn't apply your patch successfully, maybe it's corrupted or related to another version or sth]