### PR TITLE
Add TLS extensions sorting feature - fixing randomized TLS fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ For details about the ja3 fingerprint algorithm, check initial [project](https:/
 
 ### Directives
 
-No directives yet.
+Revision 110 of chrome browser introduces TLS ClientHello extensions random permutation, which makes fingerprinting irrelevant with this browser (firefox is planning to do the same).
+Using JA3_SORT_EXT cc macro during nginx configure invocation (--with-cc-opt='-DJA3_SORT_EXT') configures the module to sort TLS extensions in the JA3 string. The resulting fincgerprint is not compliant anymore with the JA3 algorithm (at this time of writing), but allow to get back effectiveness of fingerprinting.
 
 ### Variables
 

--- a/src/ngx_ssl_ja3.c
+++ b/src/ngx_ssl_ja3.c
@@ -138,6 +138,22 @@ ngx_ssj_ja3_num_digits(int n)
     return c;
 }
 
+static void
+ngx_sort_ext(unsigned short *ext, int size)
+{
+    for (int i = 0; i < size - 1; i++)
+    {
+        for (int j = 0; j < size - i - 1; j++)
+        {
+            if (ext[j] > ext[j + 1])
+            {
+                int tmp = ext[j];
+                ext[j] = ext[j + 1];
+                ext[j + 1] = tmp;
+            }
+        }
+    }
+}
 
 #if (NGX_DEBUG)
 static void
@@ -370,6 +386,9 @@ ngx_ssl_ja3(ngx_connection_t *c, ngx_pool_t *pool, ngx_ssl_ja3_t *ja3) {
                 ja3->extensions[ja3->extensions_sz++] = c->ssl->extensions[i];
             }
         }
+#ifdef JA3_SORT_EXT
+        ngx_sort_ext(ja3->extensions, ja3->extensions_sz);
+#endif
     }
 
     /* Elliptic curve points */


### PR DESCRIPTION
Hi Fooinha,
To solve the problem of randomization of tls extensions introduced in recent versions of Chrome and to keep the effectiveness of fingerprinting with these browsers, I added the ability to enable TLS extensions sorting in the fingerprint string, this breaks JA3 specification (they do not offer any solution at this time) and of course it changes fingerprints previously computed for a specific client, but it fixes fingerprint randomization.
Feel free to merge, modify or discard this request.
Regards
