### PR TITLE
Do not clone all git history (openssl)

### DIFF
--- a/docker/debian-nginx-ssl-ja3/Dockerfile
+++ b/docker/debian-nginx-ssl-ja3/Dockerfile
@@ -61,7 +61,7 @@ RUN git clone https://github.com/nginx/nginx-tests
 
 
 # Build and install openssl
-RUN git clone -v https://github.com/openssl/openssl  -b 'OpenSSL_1_1_1-stable'
+RUN git clone -v https://github.com/openssl/openssl -b 'OpenSSL_1_1_1-stable' --depth=1
 COPY patches/openssl.extensions.patch /build/openssl
 
 WORKDIR /build/openssl


### PR DESCRIPTION
Do not clone all `openssl` git history since we need just a current repo state. Save traffic, time and diskspace.