### PR TITLE
feat: fix link nginx conf by adding NGX_LIBDL

### DIFF
--- a/config
+++ b/config
@@ -34,7 +34,7 @@ ngx_feature_name="NGX_HAVE_OPENSSL_SSL_CLIENT_HELLO_CB"
 ngx_feature_run=no
 ngx_feature_incs="#include <openssl/ssl.h>"
 ngx_feature_path=
-ngx_feature_libs="-lssl -lcrypto $NGX_LD_OPT"
+ngx_feature_libs="-lssl -lcrypto $NGX_LIBDL $NGX_LIBPTHREAD"
 ngx_feature_test="SSL_CTX_set_client_hello_cb(0, 0, 0);"
 . auto/feature
 


### PR DESCRIPTION
copy from https://github.com/nginx/nginx/blob/f255815f5d161fab0dd310fe826d4f7572e141f2/auto/lib/openssl/conf#L67