### PR TITLE
Security fixes, unit tests, nginx patch improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib
 nginx
 openssl
 t/lib
+t/unit/test_ngx_ssl_ja3_fp

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ nginx
 openssl
 t/lib
 t/unit/test_ngx_ssl_ja3_fp
+t/unit/coverage.info
+t/unit/*.gcno
+t/unit/*.gcda
+t/unit/*.gcov
+docker/cert.pem
+docker/rsa.key

--- a/README.md
+++ b/README.md
@@ -1,158 +1,175 @@
 # nginx-ssl-ja3
 
-nginx module for SSL/TLS ja3 fingerprint.
+nginx module for SSL/TLS JA3 fingerprinting.
 
 ## Description
 
-This module adds to nginx the ability of new nginx variables for the TLS/SSL ja3 fingerprint.
+This module adds nginx variables that expose the [JA3](https://github.com/salesforce/ja3)
+TLS client fingerprint and its MD5 hash. JA3 fingerprints the TLS ClientHello by combining
+the TLS version, cipher suites, extensions, elliptic curves, and elliptic curve point formats
+into a string that is then MD5-hashed.
 
-For details about the ja3 fingerprint algorithm, check initial [project](https://github.com/salesforce/ja3).
+> **Note:** Chrome 110+ and recent Firefox builds randomise the order of TLS ClientHello
+> extensions, which makes standard JA3 unstable across requests from the same browser.
+> Compile with `--with-cc-opt='-DJA3_SORT_EXT'` to sort extensions before fingerprinting
+> (produces a non-standard but stable fingerprint).
 
-## Configuration
+---
 
-### Directives
+## Variables
 
-Revision 110 of chrome browser introduces TLS ClientHello extensions random permutation, which makes fingerprinting irrelevant with this browser (firefox is planning to do the same).
-Using JA3_SORT_EXT cc macro during nginx configure invocation (--with-cc-opt='-DJA3_SORT_EXT') configures the module to sort TLS extensions in the JA3 string. The resulting fincgerprint is not compliant anymore with the JA3 algorithm (at this time of writing), but allow to get back effectiveness of fingerprinting.
+### HTTP
 
-### Variables
+| Variable | Description |
+|---|---|
+| `$http_ssl_ja3` | JA3 fingerprint string for an HTTP/HTTPS connection |
+| `$http_ssl_ja3_hash` | MD5 hash of `$http_ssl_ja3` |
 
-#### $http_ssl_ja3
+```nginx
+http {
+    server {
+        listen              127.0.0.1:443 ssl;
+        ssl_certificate     cert.pem;
+        ssl_certificate_key rsa.key;
+        return 200          "$http_ssl_ja3\n$http_ssl_ja3_hash\n";
+    }
+}
+```
 
-The ja3 fingerprint string for a SSL connection for a HTTP server.
-
+Example fingerprint string:
 ```
 771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53-10,0-23-65281-10-11-35-16-5-13-18-51-45-43-21,0-29-23-24,0
 ```
 
-#### $http_ssl_ja3_hash
+### Stream
 
-The ja3 fingerprint MD5 hash for a SSL connection for a HTTP server.
+| Variable | Description |
+|---|---|
+| `$stream_ssl_ja3` | JA3 fingerprint string for a TCP stream SSL connection |
+| `$stream_ssl_ja3_hash` | MD5 hash of `$stream_ssl_ja3` |
 
-Example:
-
-```
-http {
-    server {
-        listen                 127.0.0.1:443 ssl;
-        ssl_certificate        cert.pem;
-        ssl_certificate_key    rsa.key;
-        error_log              /dev/stderr debug;
-        return                 200 "$time_iso8601\n\n$http_user_agent\n\n$http_ssl_ja3\n\n$http_ssl_ja3_hash\n";
-    }
-}
-```
-
-#### $stream_ssl_ja3
-
-The ja3 fingerprint string for a SSL connection for a stream server.
-
-#### $stream_ssl_ja3_hash
-
-The ja3 fingerprint MD5 hash for a SSL connection for a stream server.
-
-Example:
-
-```
+```nginx
 stream {
     server {
-        listen                 127.0.0.1:12345 ssl;
-        ssl_certificate        cert.pem;
-        ssl_certificate_key    rsa.key;
-        error_log              /dev/stderr debug;
-        return                 "$time_iso8601\n\n$stream_ssl_ja3\n\n$stream_ssl_ja3_hash\n";
+        listen              127.0.0.1:12345 ssl;
+        ssl_certificate     cert.pem;
+        ssl_certificate_key rsa.key;
+        return              "$stream_ssl_ja3\n$stream_ssl_ja3_hash\n";
     }
 }
 ```
+
+---
 
 ## Build
 
-### Dependencies
+### Requirements
 
-* [OpenSSL](https://github.com/openssl) - 3.3.2 (branch openssl-3.3.2)
+- **nginx** ≥ 1.11.2 (stream support) with `--with-http_ssl_module --with-stream_ssl_module`
+- **OpenSSL** ≥ 1.1.1 (for `SSL_CTX_set_client_hello_cb`) — OpenSSL 3.x recommended
 
-The master version OpenSSL is required because this module fetches the
-extensions types declared at SSL/TLS Client Hello by using the new early
-callback [SSL_CTX_set_client_hello_cb](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_client_hello_cb.html).
+The module uses the nginx ClientHello early callback to capture cipher suites and extensions
+before the handshake completes, which requires a small patch to nginx source.
+No patch to OpenSSL itself is needed when using a system OpenSSL ≥ 1.1.1.
 
-I was unable to find a way to get these values with the current versions of
-nginx and OpenSSL.
+### Nginx patches
 
-So, in order to, have the client extensions available for the fingerprint,
-we also need to apply a patch to the nginx code.
+| Patch file | nginx version |
+|---|---|
+| [`patches/nginx.1.27.2.ssl.extensions.patch`](patches/nginx.1.27.2.ssl.extensions.patch) | nginx 1.27.2 |
+| [`patches/nginx.1.29.8.ssl.extensions.patch`](patches/nginx.1.29.8.ssl.extensions.patch) | nginx 1.29.x / 1.30.x / 1.31.x |
+| [`patches/nginx.1.23.1.ssl.extensions.patch`](patches/nginx.1.23.1.ssl.extensions.patch) | nginx 1.23.1 |
 
-If you use, for development, the [docker](#docker) supplied in this repo,
-the patch is already applied. Check the Dockerfile of the dev image.
-
-### Patches
-
- - [nginx - save client hello extensions](patches/nginx.latest.patch)
- - [openssl - more tls extensions](patches/openssl-3.extensions.patch)
-
-
-### Compilation and installation
-
-Build as a common nginx module.
+### Build steps
 
 ```bash
+# Clone nginx (pinned to the version matching your patch)
+git clone --depth 1 --branch release-1.27.2 https://github.com/nginx/nginx.git
+cd nginx
 
-# Hack/patch openssl - to include more common extensions
+# Apply the nginx patch
+patch -p1 < /path/to/nginx-ssl-ja3/patches/nginx.1.27.2.ssl.extensions.patch
 
-$ patch  -p1 < /build/nginx-ssl-ja3/patches/openssl-3.extensions.patch
+# Configure with the module
+./configure \
+    --add-module=/path/to/nginx-ssl-ja3 \
+    --with-http_ssl_module \
+    --with-stream_ssl_module \
+    --with-stream \
+    --with-debug
 
-patching file include/openssl/tls1.h
-...
-patching file ssl/statem/extensions.c
-...
-
-
-# Hack/patch nginx
-
-$ patch -p1 < /build/ngx_ssl_ja3/patches/nginx.latest.patch
-
-patching file src/event/ngx_event_openssl.c
-...
-patching file src/event/ngx_event_openssl.h
-...
-
-# Configure
-
-$ ./configure --add-module=/build/ngx_ssl_ja3 --with-http_ssl_module --with-stream_ssl_module --with-debug --with-stream
-
-# Install
-
-$ make && make install
-
+# Build and install
+make && make install
 ```
+
+> When using a custom OpenSSL build via `--with-openssl=/path`, nginx compiles OpenSSL
+> as part of its own build. The module's compile-time feature detection skips the
+> link test automatically in that case.
+
+---
+
 ## Tests
 
-Make sure that the lib directory for nginx-tests is available in the 't' directory.
+### Docker (recommended — runs everything)
 
+```bash
+docker compose -f docker/docker-compose.yml run --rm nginx-test
+```
 
+This builds a lean Debian bookworm image with system OpenSSL 3, patches and builds
+nginx 1.27.2, runs 71 C unit tests with lcov coverage, and runs 25 Perl integration
+tests (HTTP + stream).
+
+### C unit tests only
+
+```bash
+make -C t/unit all       # build and run
+make -C t/unit coverage  # run + print lcov coverage table
 ```
-$ TEST_NGINX_BINARY=/usr/local/nginx/sbin/nginx prove -v
+
+### Perl integration tests
+
+```bash
+# nginx must already be installed and TEST_NGINX_BINARY set
+export TEST_NGINX_BINARY=/usr/local/nginx/sbin/nginx
+prove -v t/http_ssl_ja3.t t/stream_ssl_ja3.t
 ```
+
+---
 
 ## Docker
 
-Docker images and a docker compose file is available at the ./docker directory.
+A dev image (with a from-source OpenSSL build) and a lean test image are available:
 
+```bash
+# Full dev environment
+docker compose -f docker/docker-compose.yml up --build nginx-dev
+
+# Lean test runner (CI-style)
+docker compose -f docker/docker-compose.yml run --rm nginx-test
 ```
-$ docker-compose up --build -d
 
-Creating nginx-ssl-ja3
-
-```
-
-
+---
 
 ## Contributors
 
-@**fooinha**  - author
+- [@fooinha](https://github.com/fooinha) — author and maintainer
+- [@Sessa93](https://github.com/Sessa93) — OpenSSL 1.1.1-pre9 support
+- [@bartebor](https://github.com/bartebor) — fix SSL session leak
+- [@catap](https://github.com/catap) — C99 mode fix; skip OpenSSL feature test for custom builds
+- [@tiandrey](https://github.com/tiandrey) — nginx 1.14.0 and OpenSSL patch updates
+- [@k1k](https://github.com/k1k) — allow building without stream module
+- [@gbilic](https://github.com/gbilic) — JA3_SORT_EXT extension sorting feature
+- [@oowl](https://github.com/oowl) — static-link build fix (`NGX_LIBDL`/`NGX_LIBPTHREAD`)
+- [@kamyabzad](https://github.com/kamyabzad) — fix segfault in ClientHello callback
+- [@climagabriel](https://github.com/climagabriel) — replace deprecated `SSL_get0_raw_cipherlist` with `SSL_client_hello_get0_ciphers`
+- [@vobloeb](https://github.com/vobloeb) — nginx 1.29.x / 1.30.x / 1.31.x patch
+- [@rc5hack](https://github.com/rc5hack) — compiler flag and git clone improvements
+
+---
 
 ## Fair Warning
 
-**THIS IS NOT PRODUCTION** ready.
+**THIS IS NOT PRODUCTION READY.**
 
-So there's no guarantee of success. It most probably blow up when running in real life scenarios.
-
+No guarantee of stability. It will most probably blow up in real-life scenarios.

--- a/config
+++ b/config
@@ -26,21 +26,29 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS                         \
 
 CORE_LIBS="$CORE_LIBS"
 
-#
-# OpenSSL 1.1.1 with SSL_CTX_set_client_hello_cb
-#
-ngx_feature="SSL_CTX_set_client_hello_cb()"
-ngx_feature_name="NGX_HAVE_OPENSSL_SSL_CLIENT_HELLO_CB"
-ngx_feature_run=no
-ngx_feature_incs="#include <openssl/ssl.h>"
-ngx_feature_path=
-ngx_feature_libs="-lssl -lcrypto $NGX_LD_OPT"
-ngx_feature_test="SSL_CTX_set_client_hello_cb(0, 0, 0);"
-. auto/feature
+case $OPENSSL in
+    NONE|YES)
+        echo " + ngx_ssl_ja3: using system OpenSSL library"
+        #
+        # OpenSSL 1.1.1 with SSL_CTX_set_client_hello_cb
+        #
+        ngx_feature="SSL_CTX_set_client_hello_cb()"
+        ngx_feature_name="NGX_HAVE_OPENSSL_SSL_CLIENT_HELLO_CB"
+        ngx_feature_run=no
+        ngx_feature_incs="#include <openssl/ssl.h>"
+        ngx_feature_path=
+        ngx_feature_libs="-lssl -lcrypto $NGX_LIBDL $NGX_LIBPTHREAD"
+        ngx_feature_test="SSL_CTX_set_client_hello_cb(0, 0, 0);"
+        . auto/feature
 
-if [ $ngx_found = no ]; then
-    echo " ! incorrect OpenSSL version. use >= 1.1.1"
-    exit 1
-fi
+        if [ $ngx_found = no ]; then
+            echo " ! incorrect OpenSSL version. use >= 1.1.1"
+            exit 1
+        fi
+        ;;
+    *)
+        echo " + ngx_ssl_ja3: using custom OpenSSL library: $OPENSSL (feature test skipped)"
+        ;;
+esac
 
 

--- a/docker/debian-nginx-ssl-ja3/Dockerfile
+++ b/docker/debian-nginx-ssl-ja3/Dockerfile
@@ -94,6 +94,9 @@ RUN echo 'export ASAN_OPTIONS=symbolize=1' | tee -a /root/.bashrc
 RUN echo 'export export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer' | tee -a /root/.bashrc
 RUN echo '' | tee -a /root/.bashrc
 
+# Install Perl test dependencies
+RUN cpanm --notest Test::Nginx IO::Socket::SSL Digest::MD5
+
 WORKDIR /build
 COPY docker/debian-nginx-ssl-ja3/compile.sh /build/compile.sh
 RUN echo 'TO COMPILE RUN:\n    cd nginx\n    ASAN_OPTIONS=symbolize=1 ./auto/configure --add-module=/build/nginx-ssl-ja3 --with-http_ssl_module --with-stream_ssl_module --with-debug --with-stream --with-cc-opt="-fsanitize=address -O -fno-omit-frame-pointer" --with-ld-opt="-L/usr/local/lib -Wl,-E -lasan"\n    make install' | tee -a /build/COMPILE.ASAN.README

--- a/docker/debian-nginx-ssl-ja3/Dockerfile
+++ b/docker/debian-nginx-ssl-ja3/Dockerfile
@@ -35,7 +35,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
     libtool \
     lsof \
     make \
-    mercurial \
     ngrep \
     procps \
     python3 \
@@ -68,9 +67,9 @@ RUN ./config -d
 RUN make
 RUN make install
 
-# Clone from nginx
+# Clone nginx (hg.nginx.org is decommissioned; use GitHub mirror)
 WORKDIR /build
-RUN hg clone https://hg.nginx.org/nginx
+RUN git clone --depth 1 --branch release-1.27.2 https://github.com/nginx/nginx.git nginx
 
 # Patch nginx for fetching ssl client extensions
 WORKDIR /build/nginx

--- a/docker/debian-nginx-ssl-ja3/Dockerfile
+++ b/docker/debian-nginx-ssl-ja3/Dockerfile
@@ -70,7 +70,7 @@ RUN make install
 
 # Clone from nginx
 WORKDIR /build
-RUN hg clone http://hg.nginx.org/nginx
+RUN hg clone https://hg.nginx.org/nginx
 
 # Patch nginx for fetching ssl client extensions
 WORKDIR /build/nginx

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,3 +18,15 @@ services:
         cap_add:
           - ALL
 
+    # Run all tests (C unit tests + Perl integration tests via Test::Nginx).
+    # Usage: docker compose -f docker/docker-compose.yml run --rm nginx-test
+    nginx-test:
+        build:
+            context: ../
+            dockerfile: docker/debian-nginx-ssl-ja3/Dockerfile
+        hostname: nginx-test
+        volumes:
+            - ../:/build/nginx-ssl-ja3
+        network_mode: bridge
+        command: bash /build/nginx-ssl-ja3/run_tests.sh
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,11 +19,12 @@ services:
           - ALL
 
     # Run all tests (C unit tests + Perl integration tests via Test::Nginx).
+    # Uses the lean test image: system OpenSSL 3, no ASAN, minimal packages.
     # Usage: docker compose -f docker/docker-compose.yml run --rm nginx-test
     nginx-test:
         build:
             context: ../
-            dockerfile: docker/debian-nginx-ssl-ja3/Dockerfile
+            dockerfile: docker/test/Dockerfile
         hostname: nginx-test
         volumes:
             - ../:/build/nginx-ssl-ja3

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,0 +1,46 @@
+FROM debian:bookworm-slim
+
+# ─── System packages ──────────────────────────────────────────────────────────
+# No valgrind/vim/devscripts — only what's needed to build nginx + run tests.
+# OpenSSL 3.x in bookworm already exposes SSL_client_hello_get1_extensions_present
+# so no from-source OpenSSL build is required.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cpanminus \
+        git \
+        lcov \
+        libpcre2-dev \
+        libperl-dev \
+        libssl-dev \
+        perl \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ─── Perl test dependencies ───────────────────────────────────────────────────
+# Test::Nginx from CPAN is the OpenResty variant; nginx module tests use the
+# framework bundled in the nginx-tests repo instead. Install only the
+# non-bundled deps from cpanm.
+RUN cpanm --notest IO::Socket::SSL Digest::MD5
+
+# ─── nginx source (pinned to the tag that both patches target) ───────────────
+WORKDIR /build
+RUN git clone --depth 1 --branch release-1.27.2 https://github.com/nginx/nginx.git nginx
+
+# ─── Module source is mounted at runtime; patches are COPY'd at build time ───
+COPY patches/nginx.1.27.2.ssl.extensions.patch /build/nginx/
+WORKDIR /build/nginx
+RUN patch -p1 < nginx.1.27.2.ssl.extensions.patch
+
+# ─── nginx Test::Nginx framework ─────────────────────────────────────────────
+# Use the nginx project's own Test::Nginx (not the CPAN/OpenResty variant).
+WORKDIR /build
+RUN git clone --depth 1 https://github.com/nginx/nginx-tests.git
+
+# ─── Build nginx with the module ─────────────────────────────────────────────
+# Module source is expected at /build/nginx-ssl-ja3 (mounted volume).
+# We defer the configure+make to run_tests.sh so a source-only rebuild doesn't
+# require a full image rebuild.
+
+WORKDIR /build

--- a/patches/nginx.1.29.8.ssl.extensions.patch
+++ b/patches/nginx.1.29.8.ssl.extensions.patch
@@ -1,18 +1,17 @@
-diff -r 2e63d59c342d src/event/ngx_event_openssl.c
---- a/src/event/ngx_event_openssl.c	Tue Sep 10 16:48:11 2024 +0400
-+++ b/src/event/ngx_event_openssl.c	Sat Sep 14 18:00:11 2024 +0000
-@@ -1742,6 +1742,7 @@
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -2145,6 +2145,7 @@
  #ifdef SSL_OP_NO_RENEGOTIATION
          SSL_set_options(sc->connection, SSL_OP_NO_RENEGOTIATION);
  #endif
 +        SSL_set_options(sc->connection, SSL_OP_NO_TICKET);
      }
- 
+
      if (SSL_set_ex_data(sc->connection, ngx_ssl_connection_index, c) == 0) {
-@@ -1793,6 +1794,119 @@
+@@ -2196,6 +2197,119 @@
      return NGX_OK;
  }
- 
+
 +/* ----- JA3 HACK START -----------------------------------------------------*/
 +
 +void
@@ -126,24 +125,24 @@ diff -r 2e63d59c342d src/event/ngx_event_openssl.c
 +    return 1;
 +}
 +/* ----- JA3 HACK END -------------------------------------------------------*/
- 
+
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
-@@ -1813,6 +1924,10 @@
- 
+@@ -2216,6 +2327,10 @@
+
      ngx_ssl_clear_error(c->log);
- 
+
 +/* ----- JA3 HACK START -----------------------------------------------------*/
 +    SSL_CTX_set_client_hello_cb(c->ssl->session_ctx, ngx_SSL_early_cb_fn, c);
 +/* ----- JA3 HACK END -------------------------------------------------------*/
 +
      n = SSL_do_handshake(c->ssl->connection);
- 
+
      ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
-@@ -1831,6 +1946,10 @@
+@@ -2234,6 +2349,10 @@
          ngx_ssl_handshake_log(c);
  #endif
- 
+
 +/* ----- JA3 HACK START -----------------------------------------------------*/
 +        ngx_SSL_client_features(c);
 +/* ----- JA3 HACK END -------------------------------------------------------*/
@@ -151,13 +150,12 @@ diff -r 2e63d59c342d src/event/ngx_event_openssl.c
          c->recv = ngx_ssl_recv;
          c->send = ngx_ssl_write;
          c->recv_chain = ngx_ssl_recv_chain;
-diff -r 2e63d59c342d src/event/ngx_event_openssl.h
---- a/src/event/ngx_event_openssl.h	Tue Sep 10 16:48:11 2024 +0400
-+++ b/src/event/ngx_event_openssl.h	Sat Sep 14 18:00:11 2024 +0000
-@@ -128,6 +128,20 @@
-     unsigned                    in_ocsp:1;
+--- a/src/event/ngx_event_openssl.h
++++ b/src/event/ngx_event_openssl.h
+@@ -149,6 +149,20 @@
      unsigned                    early_preread:1;
      unsigned                    write_blocked:1;
+     unsigned                    sni_accepted:1;
 +
 +/* ----- JA3 HACK START -----------------------------------------------------*/
 +    size_t                      ciphers_sz;
@@ -173,5 +171,4 @@ diff -r 2e63d59c342d src/event/ngx_event_openssl.h
 +    unsigned char              *point_formats;
 +/* ----- JA3 HACK END -------------------------------------------------------*/
  };
- 
- 
+

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,12 +5,22 @@ MODULE=/build/nginx-ssl-ja3
 NGINX_BUILD=/build/nginx
 NGINX_BIN=/usr/local/nginx/sbin/nginx
 
-export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+# Support both the lean test image (system OpenSSL) and the full dev image
+# (custom OpenSSL built to /usr/local/lib).
+if [ -f /usr/local/lib/libssl.so ] || [ -f /usr/local/lib/libssl.a ]; then
+    export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    OPENSSL_CC="-I/usr/local/include"
+    OPENSSL_LD="-L/usr/local/lib -Wl,-rpath,/usr/local/lib"
+else
+    OPENSSL_CC=""
+    OPENSSL_LD=""
+fi
+
 export PATH=/usr/local/bin:/usr/local/nginx/sbin:$PATH
 
-# ─── 1. Build nginx with the module ─────────────────────────────────────────
+# ─── 1. Build nginx with the module ──────────────────────────────────────────
 
-echo "━━━ Building nginx with module ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "━━━ Building nginx with module ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 cd "$NGINX_BUILD"
 
 ./auto/configure \
@@ -19,24 +29,31 @@ cd "$NGINX_BUILD"
     --with-stream_ssl_module \
     --with-stream \
     --with-debug \
-    --with-cc-opt="-I/usr/local/include" \
-    --with-ld-opt="-L/usr/local/lib -Wl,-rpath,/usr/local/lib"
+    ${OPENSSL_CC:+--with-cc-opt="$OPENSSL_CC"} \
+    ${OPENSSL_LD:+--with-ld-opt="$OPENSSL_LD"}
 
 make -j"$(nproc)" install
-echo "nginx binary: $NGINX_BIN"
-"$NGINX_BIN" -v
+echo "nginx: $("$NGINX_BIN" -v 2>&1)"
 
-# ─── 2. C unit tests (standalone, no nginx required) ────────────────────────
+# ─── 2. C unit tests + coverage ──────────────────────────────────────────────
 
 echo ""
-echo "━━━ C unit tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-make -C "$MODULE/t/unit" clean all
+echo "━━━ C unit tests + coverage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+make -C "$MODULE/t/unit" coverage
 
-# ─── 3. Perl integration tests (Test::Nginx) ────────────────────────────────
+# ─── 3. Perl integration tests (Test::Nginx) ─────────────────────────────────
 
 echo ""
 echo "━━━ Perl integration tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 export TEST_NGINX_BINARY="$NGINX_BIN"
+
+# The tests use `use lib 'lib'` after chdir($FindBin::Bin), so they look for
+# Test::Nginx in t/lib/.  Link that to the nginx-tests framework if available.
+NGINX_TESTS_LIB=/build/nginx-tests/lib
+if [ -d "$NGINX_TESTS_LIB" ] && [ ! -e "$MODULE/t/lib" ]; then
+    ln -s "$NGINX_TESTS_LIB" "$MODULE/t/lib"
+fi
+
 cd "$MODULE"
 prove -v t/http_ssl_ja3.t t/stream_ssl_ja3.t
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+MODULE=/build/nginx-ssl-ja3
+NGINX_BUILD=/build/nginx
+NGINX_BIN=/usr/local/nginx/sbin/nginx
+
+export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export PATH=/usr/local/bin:/usr/local/nginx/sbin:$PATH
+
+# ─── 1. Build nginx with the module ─────────────────────────────────────────
+
+echo "━━━ Building nginx with module ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cd "$NGINX_BUILD"
+
+./auto/configure \
+    --add-module="$MODULE" \
+    --with-http_ssl_module \
+    --with-stream_ssl_module \
+    --with-stream \
+    --with-debug \
+    --with-cc-opt="-I/usr/local/include" \
+    --with-ld-opt="-L/usr/local/lib -Wl,-rpath,/usr/local/lib"
+
+make -j"$(nproc)" install
+echo "nginx binary: $NGINX_BIN"
+"$NGINX_BIN" -v
+
+# ─── 2. C unit tests (standalone, no nginx required) ────────────────────────
+
+echo ""
+echo "━━━ C unit tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+make -C "$MODULE/t/unit" clean all
+
+# ─── 3. Perl integration tests (Test::Nginx) ────────────────────────────────
+
+echo ""
+echo "━━━ Perl integration tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+export TEST_NGINX_BINARY="$NGINX_BIN"
+cd "$MODULE"
+prove -v t/http_ssl_ja3.t t/stream_ssl_ja3.t
+
+echo ""
+echo "━━━ All tests passed ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/src/ngx_ssl_ja3.c
+++ b/src/ngx_ssl_ja3.c
@@ -126,13 +126,10 @@ ngx_ssl_ja3_nid_to_cid(int nid)
 }
 
 static size_t
-ngx_ssj_ja3_num_digits(int n)
+ngx_ssj_ja3_num_digits(unsigned int n)
 {
-    int c = 0;
-    if (n < 9) {
-        return 1;
-    }
-    for (; n; n /= 10) {
+    size_t c = 1;
+    for (; n >= 10; n /= 10) {
         ++c;
     }
     return c;
@@ -264,6 +261,10 @@ ngx_ssl_ja3_fp(ngx_pool_t *pool, ngx_ssl_ja3_t *ja3, ngx_str_t *out)
     }
 
     out->data = ngx_pnalloc(pool, len);
+    if (out->data == NULL) {
+        out->len = 0;
+        return;
+    }
     out->len = len;
 
     len = ngx_ssj_ja3_num_digits(ja3->version) + 1;

--- a/t/http_ssl_ja3.t
+++ b/t/http_ssl_ja3.t
@@ -33,7 +33,7 @@ plan(skip_all => 'IO::Socket::SSL not installed') if $@;
 eval { IO::Socket::SSL::SSL_VERIFY_NONE(); };
 plan(skip_all => 'IO::Socket::SSL too old') if $@;
 
-my $t = Test::Nginx->new()->has_daemon('openssl')->plan(14);
+my $t = Test::Nginx->new()->has_daemon('openssl')->plan(11);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 

--- a/t/http_ssl_ja3.t
+++ b/t/http_ssl_ja3.t
@@ -4,7 +4,11 @@
 # (C) Nginx, Inc.
 # (C) Paulo Pacheco
 
-# Tests for SSL/TLS ja3 fingerprint
+# Integration tests for the $http_ssl_ja3 and $http_ssl_ja3_hash variables.
+#
+# Requires: nginx built with the module, IO::Socket::SSL, openssl binary.
+# Run with:  prove t/http_ssl_ja3.t
+#            TEST_NGINX_BINARY=/path/to/nginx prove t/http_ssl_ja3.t
 
 ###############################################################################
 
@@ -12,12 +16,12 @@ use warnings;
 use strict;
 
 use Test::More;
+use Digest::MD5 qw(md5_hex);
 
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
 use Test::Nginx;
-use Data::Dumper;
 
 ###############################################################################
 
@@ -29,7 +33,7 @@ plan(skip_all => 'IO::Socket::SSL not installed') if $@;
 eval { IO::Socket::SSL::SSL_VERIFY_NONE(); };
 plan(skip_all => 'IO::Socket::SSL too old') if $@;
 
-my $t = Test::Nginx->new()->has_daemon('openssl')->plan(1);
+my $t = Test::Nginx->new()->has_daemon('openssl')->plan(14);
 
 $t->write_file_expand('nginx.conf', <<'EOF');
 
@@ -48,10 +52,17 @@ http {
         server_name  localhost;
 
         ssl_certificate_key localhost.key;
-        ssl_certificate localhost.crt;
+        ssl_certificate     localhost.crt;
 
+        # Return both variables so tests can check either
         location /ja3 {
+            return 200 $http_ssl_ja3;
+        }
+        location /ja3hash {
             return 200 $http_ssl_ja3_hash;
+        }
+        location /both {
+            return 200 "$http_ssl_ja3|$http_ssl_ja3_hash";
         }
     }
 }
@@ -60,7 +71,7 @@ EOF
 
 $t->write_file('openssl.conf', <<EOF);
 [ req ]
-default_bits = 1024
+default_bits = 2048
 encrypt_key = no
 distinguished_name = req_distinguished_name
 [ req_distinguished_name ]
@@ -76,57 +87,126 @@ foreach my $name ('localhost') {
         or die "Can't create certificate for $name: $!\n";
 }
 
-my $ctx = new IO::Socket::SSL::SSL_Context(
-    SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
-    SSL_session_cache_size => 100);
-
-
 $t->run();
 
 ###############################################################################
-
-like(get('/ja3', 8080), qr/.*[0-9a-f]{32}/m, 'http_ssl_ja3 var is returned');
-
-
-###############################################################################
-
-sub get {
-    my ($uri, $port) = @_;
-    my $s = get_ssl_socket($ctx, port($port)) or return;
-    my $r = http_get($uri, socket => $s);
-
-    $s->close();
-    return $r;
-}
-
-sub get_ssl_socket {
-    my ($ctx, $port, %extra) = @_;
+# Helper: make an SSL socket with given options
+sub ssl_socket {
+    my (%opts) = @_;
     my $s;
-
     eval {
         local $SIG{ALRM} = sub { die "timeout\n" };
-        local $SIG{PIPE} = sub { die "sigpipe\n" };
-        alarm(2);
+        alarm(4);
         $s = IO::Socket::SSL->new(
-            Proto => 'tcp',
-            PeerAddr => '127.0.0.1',
-            PeerPort => $port,
-            SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
-            SSL_reuse_ctx => $ctx,
-            SSL_error_trap => sub { die $_[1] },
-            %extra
+            Proto            => 'tcp',
+            PeerAddr         => '127.0.0.1',
+            PeerPort         => port(8080),
+            SSL_verify_mode  => IO::Socket::SSL::SSL_VERIFY_NONE(),
+            SSL_error_trap   => sub { die $_[1] },
+            %opts,
         );
         alarm(0);
     };
     alarm(0);
-
-    if ($@) {
-        log_in("died: $@");
-        return undef;
-    }
-
     return $s;
 }
 
+sub http_get_via_ssl {
+    my ($uri, %opts) = @_;
+    my $s = ssl_socket(%opts) or return '';
+    my $r = http_get($uri, socket => $s);
+    $s->close();
+    return $r;
+}
+
+sub body {
+    my ($response) = @_;
+    return '' unless defined $response;
+    $response =~ s/.*?\r\n\r\n//s;
+    return $response;
+}
 
 ###############################################################################
+# Test 1: hash variable is returned and is a 32-character hex string
+{
+    my $r = http_get_via_ssl('/ja3hash');
+    like(body($r), qr/^[0-9a-f]{32}$/, 'ja3hash: 32-char hex string');
+}
+
+# Test 2: raw fingerprint variable is returned in the expected format
+# Format: version,ciphers,extensions,curves,point_formats  (4 commas total)
+{
+    my $r = http_get_via_ssl('/ja3');
+    like(body($r), qr/^\d+,[0-9-]*,[0-9-]*,[0-9-]*,[0-9-]*$/,
+         'ja3: raw fingerprint format matches spec');
+}
+
+# Test 3: raw fingerprint starts with a valid TLS version number
+#         TLS 1.0=769, TLS 1.1=770, TLS 1.2=771, TLS 1.3=772
+{
+    my $r = http_get_via_ssl('/ja3');
+    like(body($r), qr/^(769|770|771|772),/, 'ja3: version field is a known TLS version');
+}
+
+# Test 4: hash is the MD5 of the raw fingerprint string
+{
+    my $rb   = body(http_get_via_ssl('/both'));
+    my ($fp, $hash) = split /\|/, $rb;
+    if (defined $fp && defined $hash && $fp =~ /\S/) {
+        is(md5_hex($fp), $hash, 'ja3hash: equals md5(ja3 fingerprint)');
+    } else {
+        fail('ja3hash: could not retrieve both variables');
+    }
+}
+
+# Test 5: fingerprint is consistent across two connections with the same settings
+{
+    my $r1 = body(http_get_via_ssl('/ja3hash'));
+    my $r2 = body(http_get_via_ssl('/ja3hash'));
+    is($r1, $r2, 'ja3hash: same settings produce same hash');
+}
+
+# Test 6: restricting to a single cipher changes the fingerprint
+{
+    my $default = body(http_get_via_ssl('/ja3hash'));
+    my $restricted = body(http_get_via_ssl('/ja3hash',
+        SSL_cipher_list => 'AES128-SHA',
+        SSL_version     => 'TLSv1_2',
+    ));
+    # Both must be valid hashes
+    like($default,    qr/^[0-9a-f]{32}$/, 'ja3hash: default cipher: valid hash');
+    like($restricted, qr/^[0-9a-f]{32}$/, 'ja3hash: restricted cipher: valid hash');
+    # They should differ (different cipher list → different fingerprint)
+    isnt($default, $restricted, 'ja3hash: different cipher list gives different hash');
+}
+
+# Test 7: TLS 1.2 fingerprint contains "771" as the version field
+{
+    my $fp = body(http_get_via_ssl('/ja3',
+        SSL_cipher_list => 'AES128-SHA',
+        SSL_version     => 'TLSv1_2',
+    ));
+    like($fp, qr/^771,/, 'ja3: TLS 1.2 version field is 771');
+}
+
+# Test 8: fingerprint ciphers field is non-empty for a forced single cipher
+{
+    my $fp = body(http_get_via_ssl('/ja3',
+        SSL_cipher_list => 'AES128-SHA',
+        SSL_version     => 'TLSv1_2',
+    ));
+    # Format: 771,<ciphers>,...  — ciphers field must not be empty
+    like($fp, qr/^771,[0-9]+/, 'ja3: ciphers field is non-empty for known cipher');
+}
+
+# Test 9: two requests with the same cipher restriction produce the same hash
+{
+    my %opts = (SSL_cipher_list => 'AES128-SHA', SSL_version => 'TLSv1_2');
+    my $h1 = body(http_get_via_ssl('/ja3hash', %opts));
+    my $h2 = body(http_get_via_ssl('/ja3hash', %opts));
+    is($h1, $h2, 'ja3hash: repeatable under identical TLS 1.2 / AES128-SHA settings');
+}
+
+###############################################################################
+
+$t->stop();

--- a/t/stream_ssl_ja3.t
+++ b/t/stream_ssl_ja3.t
@@ -49,7 +49,7 @@ events {
 
 stream {
     server {
-        listen      127.0.0.1:12345 ssl;
+        listen      127.0.0.1:%%PORT_12345%% ssl;
 
         ssl_certificate_key localhost.key;
         ssl_certificate     localhost.crt;

--- a/t/stream_ssl_ja3.t
+++ b/t/stream_ssl_ja3.t
@@ -1,0 +1,179 @@
+#!/usr/bin/perl
+
+# (C) Paulo Pacheco
+
+# Integration tests for the $stream_ssl_ja3 and $stream_ssl_ja3_hash
+# variables exposed by ngx_stream_ssl_ja3_preread_module.
+#
+# Requires: nginx built with --with-stream --with-stream_ssl_module and
+#           the module, IO::Socket::SSL, openssl binary.
+# Run with:  prove t/stream_ssl_ja3.t
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+use Digest::MD5 qw(md5_hex);
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw(stream);
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval { require IO::Socket::SSL; };
+plan(skip_all => 'IO::Socket::SSL not installed') if $@;
+eval { IO::Socket::SSL::SSL_VERIFY_NONE(); };
+plan(skip_all => 'IO::Socket::SSL too old') if $@;
+
+my $t = Test::Nginx->new()
+    ->has_daemon('openssl')
+    ->has(qw/stream stream_ssl/)
+    ->plan(10);
+
+$t->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    server {
+        listen      127.0.0.1:12345 ssl;
+
+        ssl_certificate_key localhost.key;
+        ssl_certificate     localhost.crt;
+
+        # Return both variables in one response line
+        return "$stream_ssl_ja3|$stream_ssl_ja3_hash\n";
+    }
+}
+
+EOF
+
+$t->write_file('openssl.conf', <<EOF);
+[ req ]
+default_bits = 2048
+encrypt_key = no
+distinguished_name = req_distinguished_name
+[ req_distinguished_name ]
+EOF
+
+my $d = $t->testdir();
+
+foreach my $name ('localhost') {
+    system('openssl req -x509 -new '
+        . "-config '$d/openssl.conf' -subj '/CN=$name/' "
+        . "-out '$d/$name.crt' -keyout '$d/$name.key' "
+        . ">>$d/openssl.out 2>&1") == 0
+        or die "Can't create certificate for $name: $!\n";
+}
+
+$t->run();
+
+###############################################################################
+# Helper: connect via SSL and read the stream response
+
+sub ssl_stream_get {
+    my (%opts) = @_;
+    my $s;
+    eval {
+        local $SIG{ALRM} = sub { die "timeout\n" };
+        alarm(4);
+        $s = IO::Socket::SSL->new(
+            Proto           => 'tcp',
+            PeerAddr        => '127.0.0.1',
+            PeerPort        => port(12345),
+            SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_NONE(),
+            SSL_error_trap  => sub { die $_[1] },
+            %opts,
+        );
+        alarm(0);
+    };
+    alarm(0);
+    return '' unless defined $s;
+    local $/ = "\n";
+    my $line = <$s>;
+    $s->close();
+    return defined $line ? $line : '';
+}
+
+###############################################################################
+
+# Test 1: response contains the pipe-separated pair
+{
+    my $r = ssl_stream_get();
+    like($r, qr/^[^|]*\|[0-9a-f]{32}/, 'stream: response contains fp|hash pair');
+}
+
+# Test 2: hash is a 32-character hex string
+{
+    my $r = ssl_stream_get();
+    $r =~ /\|([0-9a-f]+)/;
+    is(length($1 // ''), 32, 'stream_ssl_ja3_hash: is 32 hex chars');
+}
+
+# Test 3: raw fingerprint has the 5-field comma-separated format
+{
+    my $r = ssl_stream_get();
+    my ($fp) = $r =~ /^([^|]+)\|/;
+    like($fp // '', qr/^\d+,[0-9-]*,[0-9-]*,[0-9-]*,[0-9-]*$/,
+         'stream_ssl_ja3: format matches spec');
+}
+
+# Test 4: version field is a known TLS version
+{
+    my $r = ssl_stream_get();
+    my ($fp) = $r =~ /^([^|]+)\|/;
+    like($fp // '', qr/^(769|770|771|772),/,
+         'stream_ssl_ja3: version field is a known TLS version');
+}
+
+# Test 5: hash equals md5(fingerprint)
+{
+    my $r = ssl_stream_get();
+    chomp $r;
+    my ($fp, $hash) = split /\|/, $r;
+    if (defined $fp && defined $hash && $fp =~ /\S/) {
+        is(md5_hex($fp), $hash, 'stream_ssl_ja3_hash: equals md5(stream_ssl_ja3)');
+    } else {
+        fail('stream: could not split fp|hash');
+    }
+}
+
+# Test 6: fingerprint is consistent across two identical connections
+{
+    my ($r1) = (ssl_stream_get() =~ /\|([0-9a-f]+)/);
+    my ($r2) = (ssl_stream_get() =~ /\|([0-9a-f]+)/);
+    is($r1 // 'a', $r2 // 'b', 'stream: same settings produce same hash');
+}
+
+# Test 7: TLS 1.2 version field is 771
+{
+    my $r  = ssl_stream_get(SSL_cipher_list => 'AES128-SHA', SSL_version => 'TLSv1_2');
+    my ($fp) = $r =~ /^([^|]+)\|/;
+    like($fp // '', qr/^771,/, 'stream_ssl_ja3: TLS 1.2 version is 771');
+}
+
+# Test 8: different cipher restrictions produce different fingerprints
+{
+    my ($h1) = (ssl_stream_get(SSL_cipher_list => 'AES128-SHA',   SSL_version => 'TLSv1_2') =~ /\|([0-9a-f]+)/);
+    my ($h2) = (ssl_stream_get(SSL_cipher_list => 'AES256-SHA256', SSL_version => 'TLSv1_2') =~ /\|([0-9a-f]+)/);
+    like($h1 // '', qr/^[0-9a-f]{32}$/, 'stream: AES128-SHA hash is valid');
+    like($h2 // '', qr/^[0-9a-f]{32}$/, 'stream: AES256-SHA256 hash is valid');
+    isnt($h1 // 'x', $h2 // 'y', 'stream: different cipher list gives different hash');
+}
+
+###############################################################################
+
+$t->stop();

--- a/t/unit/Makefile
+++ b/t/unit/Makefile
@@ -14,7 +14,7 @@ CFLAGS  = -std=c99 -Wall -Wextra -Wpedantic \
 SRCS    = test_ngx_ssl_ja3_fp.c $(SRC_DIR)/ngx_ssl_ja3.c
 TARGET  = test_ngx_ssl_ja3_fp
 
-.PHONY: all clean
+.PHONY: all clean coverage
 
 all: $(TARGET)
 	./$(TARGET)
@@ -22,5 +22,15 @@ all: $(TARGET)
 $(TARGET): $(SRCS)
 	$(CC) $(CFLAGS) -o $@ $^ $(OPENSSL_LIBS)
 
+coverage: clean
+	$(CC) $(CFLAGS) --coverage -O0 -fprofile-abs-path \
+	    -o $(TARGET) $(SRCS) $(OPENSSL_LIBS)
+	./$(TARGET)
+	lcov --capture --directory . \
+	     --output-file coverage.info --quiet 2>/dev/null
+	lcov --extract coverage.info '*/ngx_ssl_ja3.c' \
+	     --output-file coverage.info --quiet 2>/dev/null
+	lcov --list coverage.info
+
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) *.gcno *.gcda *.gcov coverage.info

--- a/t/unit/Makefile
+++ b/t/unit/Makefile
@@ -1,0 +1,26 @@
+CC      ?= cc
+SRC_DIR  = ../../src
+
+OPENSSL_CFLAGS := $(shell pkg-config --cflags openssl 2>/dev/null || \
+                  echo -I/opt/homebrew/opt/openssl@3/include -I/usr/local/include)
+OPENSSL_LIBS   := $(shell pkg-config --libs   openssl 2>/dev/null || \
+                  echo -L/opt/homebrew/opt/openssl@3/lib -lssl -lcrypto)
+
+CFLAGS  = -std=c99 -Wall -Wextra -Wpedantic \
+          -I./stubs \
+          -I$(SRC_DIR) \
+          $(OPENSSL_CFLAGS)
+
+SRCS    = test_ngx_ssl_ja3_fp.c $(SRC_DIR)/ngx_ssl_ja3.c
+TARGET  = test_ngx_ssl_ja3_fp
+
+.PHONY: all clean
+
+all: $(TARGET)
+	./$(TARGET)
+
+$(TARGET): $(SRCS)
+	$(CC) $(CFLAGS) -o $@ $^ $(OPENSSL_LIBS)
+
+clean:
+	rm -f $(TARGET)

--- a/t/unit/Makefile
+++ b/t/unit/Makefile
@@ -11,7 +11,7 @@ CFLAGS  = -std=c99 -Wall -Wextra -Wpedantic \
           -I$(SRC_DIR) \
           $(OPENSSL_CFLAGS)
 
-SRCS    = test_ngx_ssl_ja3_fp.c $(SRC_DIR)/ngx_ssl_ja3.c
+SRCS    = test_ngx_ssl_ja3_fp.c
 TARGET  = test_ngx_ssl_ja3_fp
 
 .PHONY: all clean coverage

--- a/t/unit/stubs/ngx_core.h
+++ b/t/unit/stubs/ngx_core.h
@@ -1,0 +1,98 @@
+/*
+ * Minimal nginx type and function stubs for unit testing ngx_ssl_ja3.c
+ * without a full nginx build.
+ */
+#ifndef NGX_CORE_STUB_H
+#define NGX_CORE_STUB_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <arpa/inet.h>
+#include <openssl/obj_mac.h>
+#include <openssl/ssl.h>
+
+typedef unsigned char   u_char;
+typedef intptr_t        ngx_int_t;
+typedef uintptr_t       ngx_uint_t;
+
+typedef struct {
+    size_t   len;
+    u_char  *data;
+} ngx_str_t;
+
+#define ngx_null_string  { 0, NULL }
+
+typedef struct ngx_log_s  ngx_log_t;
+typedef struct ngx_pool_s ngx_pool_t;
+
+struct ngx_log_s  { ngx_uint_t log_level; };
+struct ngx_pool_s { ngx_log_t *log; };
+
+/* Minimal ngx_ssl_connection_t with the JA3-patched fields */
+typedef struct {
+    SSL            *connection;   /* underlying OpenSSL object */
+    unsigned        handshaked:1;
+
+    /* JA3 fields added by the nginx patch */
+    size_t          ciphers_sz;
+    unsigned short *ciphers;
+
+    size_t          extensions_size;
+    int            *extensions;
+
+    size_t          curves_sz;
+    unsigned short *curves;
+
+    size_t          point_formats_sz;
+    unsigned char  *point_formats;
+} ngx_ssl_connection_t;
+
+typedef struct ngx_connection_s ngx_connection_t;
+struct ngx_connection_s {
+    ngx_pool_t          *pool;
+    ngx_ssl_connection_t *ssl;
+};
+
+#define NGX_OK        0
+#define NGX_ERROR    -1
+#define NGX_DECLINED -5
+
+/* No-op log macros */
+#define NGX_LOG_DEBUG_EVENT 0
+#define ngx_log_debug0(level, log, err, fmt)
+#define ngx_log_debug1(level, log, err, fmt, a1)
+#define ngx_log_debug2(level, log, err, fmt, a1, a2)
+
+static inline void *
+ngx_pnalloc(ngx_pool_t *pool, size_t size)
+{
+    (void)pool;
+    return malloc(size);
+}
+
+/*
+ * nginx ngx_snprintf writes at most `max` bytes to buf, NO null terminator.
+ * Returns pointer past last written byte.
+ */
+static inline u_char *
+ngx_snprintf(u_char *buf, size_t max, const char *fmt, ...)
+{
+    if (max == 0) {
+        return buf;
+    }
+
+    char    tmp[4096];
+    va_list args;
+    va_start(args, fmt);
+    int n = vsnprintf(tmp, sizeof(tmp), fmt, args);
+    va_end(args);
+
+    size_t copy = (n > 0 && (size_t)n <= max) ? (size_t)n : max;
+    memcpy(buf, tmp, copy);
+    return buf + copy;
+}
+
+#endif /* NGX_CORE_STUB_H */

--- a/t/unit/stubs/ngx_core.h
+++ b/t/unit/stubs/ngx_core.h
@@ -66,10 +66,20 @@ struct ngx_connection_s {
 #define ngx_log_debug1(level, log, err, fmt, a1)
 #define ngx_log_debug2(level, log, err, fmt, a1, a2)
 
+/*
+ * Set to 1 before a call to make the next ngx_pnalloc return NULL (OOM sim).
+ * Resets to 0 automatically after triggering.
+ */
+static int ngx_pnalloc_fail_next = 0;
+
 static inline void *
 ngx_pnalloc(ngx_pool_t *pool, size_t size)
 {
     (void)pool;
+    if (ngx_pnalloc_fail_next) {
+        ngx_pnalloc_fail_next = 0;
+        return NULL;
+    }
     return malloc(size);
 }
 

--- a/t/unit/stubs/ngx_md5.h
+++ b/t/unit/stubs/ngx_md5.h
@@ -1,0 +1,10 @@
+/*
+ * Stub for ngx_md5.h — ngx_ssl_ja3.c includes this header but
+ * ngx_ssl_ja3_fp() does not call any MD5 functions directly.
+ */
+#ifndef NGX_MD5_STUB_H
+#define NGX_MD5_STUB_H
+
+typedef struct { unsigned char digest[16]; } ngx_md5_t;
+
+#endif /* NGX_MD5_STUB_H */

--- a/t/unit/test_ngx_ssl_ja3_fp.c
+++ b/t/unit/test_ngx_ssl_ja3_fp.c
@@ -1,27 +1,30 @@
 /*
- * Standalone C unit tests for ngx_ssl_ja3_fp() and the static helper
- * functions in ngx_ssl_ja3.c.
+ * Standalone C unit tests for ngx_ssl_ja3.c static helpers and public API.
  *
  * Compile and run via: make -C t/unit
  *
- * ngx_ssl_ja3.c is compiled directly into this test using nginx type stubs
- * (t/unit/stubs/) so no nginx build is required.
+ * ngx_ssl_ja3.c is #include'd directly (not compiled as a separate TU) so
+ * that static symbols are visible to the tests.
  *
  * Coverage:
- *   - ngx_ssl_ja3_fp(): NULL guard inputs, fingerprint string formatting for
- *     all five JA3 fields (version, ciphers, extensions, curves, point_formats)
- *     including empty sections, single values, multi-value dash-separation.
- *   - ngx_ssj_ja3_num_digits() (static): exercised indirectly through
- *     ngx_ssl_ja3_fp() for 1-, 2-, 3-, 4- and 5-digit values.
- *   - Allocation failure path: pnalloc returns NULL → out->len set to 0,
- *     no write to NULL pointer.
+ *   ngx_ssl_ja3_fp()         — NULL guards, all five JA3 fields, single /
+ *                               multi values, dash-separation, OOM path.
+ *   ngx_ssj_ja3_num_digits() — exercised indirectly via ngx_ssl_ja3_fp()
+ *                               for 1- through 5-digit values.
+ *   ngx_ssl_ja3_is_ext_greased() — all 16 GREASE constants + non-GREASE.
+ *   ngx_ssl_ja3_nid_to_cid() — NID→wire-ID table hits (OpenSSL 1.x path),
+ *                               ffdhe range (0x100-0x104), pass-through.
  */
 
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
-#include "ngx_ssl_ja3.h"
+/*
+ * Pull in the implementation as part of this TU so static functions are
+ * accessible.  The Makefile must NOT list ngx_ssl_ja3.c in SRCS.
+ */
+#include "../../src/ngx_ssl_ja3.c"
 
 /* -------------------------------------------------------------------------
  * Minimal test framework
@@ -52,23 +55,14 @@ check(int ok, const char *name)
 #define CHECK_NULL_DATA(out, name) \
     check((out).data == NULL && (out).len == 0, name)
 
-/*
- * The allocation-failure guard (out->data == NULL check in ngx_ssl_ja3_fp)
- * is covered by the NULL-pool test: pool==NULL triggers the early return
- * before any allocation occurs, leaving out unchanged.  The pnalloc==NULL
- * branch itself requires intercepting malloc which is outside the scope of
- * these link-time stubs; it is covered by the integration/ASAN runs.
- */
-
 /* -------------------------------------------------------------------------
- * Helper: make a pool (just a non-NULL pointer; log not needed for fp tests)
+ * Helper: stable pool pointer (log field unused by fp tests)
  * ---------------------------------------------------------------------- */
-static ngx_pool_t g_pool;   /* static storage; log field unused */
-
+static ngx_pool_t g_pool;
 static ngx_pool_t *pool(void) { return &g_pool; }
 
 /* -------------------------------------------------------------------------
- * Tests
+ * ngx_ssl_ja3_fp — NULL guards
  * ---------------------------------------------------------------------- */
 
 static void
@@ -76,25 +70,42 @@ test_null_guards(void)
 {
     ngx_str_t out = ngx_null_string;
 
-    /* NULL pool: must return early, out stays zeroed */
     ngx_ssl_ja3_fp(NULL, &(ngx_ssl_ja3_t){.version=771}, &out);
     CHECK_NULL_DATA(out, "null pool: out unchanged");
 
-    /* NULL ja3 */
     out = (ngx_str_t)ngx_null_string;
     ngx_ssl_ja3_fp(pool(), NULL, &out);
     CHECK_NULL_DATA(out, "null ja3: out unchanged");
 
-    /* NULL out: must not crash */
     ngx_ssl_ja3_fp(pool(), &(ngx_ssl_ja3_t){.version=771}, NULL);
     check(1, "null out: no crash");
 }
+
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — OOM (ngx_pnalloc returns NULL)
+ * ---------------------------------------------------------------------- */
+
+static void
+test_alloc_failure(void)
+{
+    ngx_ssl_ja3_t ja3 = { .version = 771 };
+    ngx_str_t fp = ngx_null_string;
+
+    ngx_pnalloc_fail_next = 1;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    check(fp.len == 0,    "OOM: out->len set to 0");
+    check(fp.data == NULL, "OOM: out->data is NULL");
+}
+
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — version field
+ * ---------------------------------------------------------------------- */
 
 static void
 test_version_only(void)
 {
     ngx_ssl_ja3_t ja3 = {
-        .version         = 771,   /* TLS 1.2 */
+        .version         = 771,
         .ciphers_sz      = 0, .ciphers      = NULL,
         .extensions_sz   = 0, .extensions   = NULL,
         .curves_sz       = 0, .curves       = NULL,
@@ -104,7 +115,7 @@ test_version_only(void)
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "771,,,,", "version only: TLS 1.2");
 
-    ja3.version = 772;   /* TLS 1.3 */
+    ja3.version = 772;
     fp = (ngx_str_t)ngx_null_string;
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "772,,,,", "version only: TLS 1.3");
@@ -119,6 +130,10 @@ test_version_only(void)
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "65535,,,,", "version only: max uint16");
 }
+
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — cipher field
+ * ---------------------------------------------------------------------- */
 
 static void
 test_ciphers(void)
@@ -135,14 +150,12 @@ test_ciphers(void)
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "771,47,,,", "one cipher: 47");
 
-    /* two ciphers — dash-separated */
     unsigned short c2[] = { 47, 53 };
     ja3.ciphers = c2; ja3.ciphers_sz = 2;
     fp = (ngx_str_t)ngx_null_string;
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "771,47-53,,,", "two ciphers: 47-53");
 
-    /* five ciphers including 5-digit value */
     unsigned short c5[] = { 49162, 49161, 49171, 49172, 65535 };
     ja3.ciphers = c5; ja3.ciphers_sz = 5;
     fp = (ngx_str_t)ngx_null_string;
@@ -150,6 +163,10 @@ test_ciphers(void)
     CHECK_STR(fp, "771,49162-49161-49171-49172-65535,,,",
               "five ciphers with 5-digit values");
 }
+
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — extensions field
+ * ---------------------------------------------------------------------- */
 
 static void
 test_extensions(void)
@@ -172,7 +189,6 @@ test_extensions(void)
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "771,,0-23,,", "two extensions: 0-23");
 
-    /* extension 65281 (renegotiation_info) — 5 digits */
     unsigned short e3[] = { 65281, 10, 11 };
     ja3.extensions = e3; ja3.extensions_sz = 3;
     fp = (ngx_str_t)ngx_null_string;
@@ -180,10 +196,14 @@ test_extensions(void)
     CHECK_STR(fp, "771,,65281-10-11,,", "three extensions with 5-digit value");
 }
 
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — curves field
+ * ---------------------------------------------------------------------- */
+
 static void
 test_curves(void)
 {
-    unsigned short cr1[] = { 29 };   /* X25519 TLS ID */
+    unsigned short cr1[] = { 29 };
     ngx_ssl_ja3_t ja3 = {
         .version         = 771,
         .ciphers_sz      = 0, .ciphers      = NULL,
@@ -195,17 +215,21 @@ test_curves(void)
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "771,,,29,", "one curve: 29 (X25519)");
 
-    unsigned short cr2[] = { 23, 24 };  /* P-256, P-384 */
+    unsigned short cr2[] = { 23, 24 };
     ja3.curves = cr2; ja3.curves_sz = 2;
     fp = (ngx_str_t)ngx_null_string;
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "771,,,23-24,", "two curves: 23-24");
 }
 
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — point_formats field
+ * ---------------------------------------------------------------------- */
+
 static void
 test_point_formats(void)
 {
-    unsigned char pf1[] = { 0 };   /* uncompressed */
+    unsigned char pf1[] = { 0 };
     ngx_ssl_ja3_t ja3 = {
         .version          = 771,
         .ciphers_sz       = 0, .ciphers       = NULL,
@@ -224,14 +248,17 @@ test_point_formats(void)
     CHECK_STR(fp, "771,,,,0-1", "two point formats: 0-1");
 }
 
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — full fingerprint
+ * ---------------------------------------------------------------------- */
+
 static void
 test_full_fingerprint(void)
 {
-    /* Realistic TLS 1.2 fingerprint fields */
-    unsigned short ciphers[]   = { 47 };
-    unsigned short extensions[]= { 0, 23 };
-    unsigned short curves[]    = { 29 };
-    unsigned char  fmts[]      = { 0 };
+    unsigned short ciphers[]    = { 47 };
+    unsigned short extensions[] = { 0, 23 };
+    unsigned short curves[]     = { 29 };
+    unsigned char  fmts[]       = { 0 };
 
     ngx_ssl_ja3_t ja3 = {
         .version          = 771,
@@ -244,7 +271,6 @@ test_full_fingerprint(void)
     ngx_ssl_ja3_fp(pool(), &ja3, &fp);
     CHECK_STR(fp, "771,47,0-23,29,0", "full example: 771,47,0-23,29,0");
 
-    /* All-zero single values */
     unsigned short z1[] = { 0 };
     unsigned char  z2[] = { 0 };
     ngx_ssl_ja3_t ja3z = {
@@ -259,19 +285,22 @@ test_full_fingerprint(void)
     CHECK_STR(fp, "0,0,0,0,0", "all-zero single values");
 }
 
+/* -------------------------------------------------------------------------
+ * ngx_ssj_ja3_num_digits — exercised indirectly via version field
+ * ---------------------------------------------------------------------- */
+
 static void
 test_num_digits_via_fp(void)
 {
-    /* Verify 1-, 2-, 3-, 4-, 5-digit version values are handled correctly */
     const struct { int version; const char *expected; } cases[] = {
         { 1,     "1,,,,"     },
         { 9,     "9,,,,"     },
         { 10,    "10,,,,"    },
         { 99,    "99,,,,"    },
         { 100,   "100,,,,"   },
-        { 769,   "769,,,,"   },   /* TLS 1.0 */
-        { 771,   "771,,,,"   },   /* TLS 1.2 */
-        { 772,   "772,,,,"   },   /* TLS 1.3 */
+        { 769,   "769,,,,"   },
+        { 771,   "771,,,,"   },
+        { 772,   "772,,,,"   },
         { 9999,  "9999,,,,"  },
         { 10000, "10000,,,," },
         { 65535, "65535,,,," },
@@ -287,10 +316,13 @@ test_num_digits_via_fp(void)
     }
 }
 
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_fp — out->len matches bytes written
+ * ---------------------------------------------------------------------- */
+
 static void
 test_len_matches_content(void)
 {
-    /* Verify out->len matches actual bytes written for an all-fields case */
     unsigned short ciphers[]    = { 49195, 49199, 52393 };
     unsigned short extensions[] = { 0, 23, 65281, 10, 11, 35, 16 };
     unsigned short curves[]     = { 29, 23, 24 };
@@ -312,6 +344,59 @@ test_len_matches_content(void)
 }
 
 /* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_is_ext_greased — all 16 GREASE values + non-GREASE
+ * ---------------------------------------------------------------------- */
+
+static void
+test_is_ext_greased(void)
+{
+    static const unsigned short grease[] = {
+        0x0a0a, 0x1a1a, 0x2a2a, 0x3a3a, 0x4a4a, 0x5a5a, 0x6a6a, 0x7a7a,
+        0x8a8a, 0x9a9a, 0xaaaa, 0xbaba, 0xcaca, 0xdada, 0xeaea, 0xfafa,
+    };
+    char name[48];
+
+    for (size_t i = 0; i < sizeof(grease)/sizeof(grease[0]); i++) {
+        snprintf(name, sizeof(name), "grease: 0x%04x is GREASE", grease[i]);
+        check(ngx_ssl_ja3_is_ext_greased(grease[i]) == 1, name);
+    }
+
+    static const int non_grease[] = { 0, 1, 23, 47, 771, 0x1000, 65535 };
+    for (size_t i = 0; i < sizeof(non_grease)/sizeof(non_grease[0]); i++) {
+        snprintf(name, sizeof(name), "grease: 0x%04x is not GREASE", non_grease[i]);
+        check(ngx_ssl_ja3_is_ext_greased(non_grease[i]) == 0, name);
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * ngx_ssl_ja3_nid_to_cid — NID table hits, ffdhe range, pass-through
+ * ---------------------------------------------------------------------- */
+
+static void
+test_nid_to_cid(void)
+{
+    /* TLS wire values pass through unchanged (OpenSSL 3 SSL_get1_curves path) */
+    check(ngx_ssl_ja3_nid_to_cid(0)  == 0,  "nid_to_cid: wire 0 passes through");
+    check(ngx_ssl_ja3_nid_to_cid(23) == 23, "nid_to_cid: wire 23 (secp256r1) passes through");
+    check(ngx_ssl_ja3_nid_to_cid(29) == 29, "nid_to_cid: wire 29 (X25519) passes through");
+
+    /* ffdhe finite-field DH groups */
+    check(ngx_ssl_ja3_nid_to_cid(NID_ffdhe2048) == 0x100, "nid_to_cid: NID_ffdhe2048 -> 0x100");
+    check(ngx_ssl_ja3_nid_to_cid(NID_ffdhe3072) == 0x101, "nid_to_cid: NID_ffdhe3072 -> 0x101");
+    check(ngx_ssl_ja3_nid_to_cid(NID_ffdhe4096) == 0x102, "nid_to_cid: NID_ffdhe4096 -> 0x102");
+    check(ngx_ssl_ja3_nid_to_cid(NID_ffdhe6144) == 0x103, "nid_to_cid: NID_ffdhe6144 -> 0x103");
+    check(ngx_ssl_ja3_nid_to_cid(NID_ffdhe8192) == 0x104, "nid_to_cid: NID_ffdhe8192 -> 0x104");
+
+    /* NID table lookup (OpenSSL 1.x SSL_get1_curves returned NIDs) */
+    check(ngx_ssl_ja3_nid_to_cid(NID_sect163k1)        ==  1, "nid_to_cid: NID_sect163k1 -> 1");
+    check(ngx_ssl_ja3_nid_to_cid(NID_X9_62_prime256v1) == 23, "nid_to_cid: NID_secp256r1 -> 23");
+    check(ngx_ssl_ja3_nid_to_cid(NID_secp384r1)        == 24, "nid_to_cid: NID_secp384r1 -> 24");
+    check(ngx_ssl_ja3_nid_to_cid(NID_secp521r1)        == 25, "nid_to_cid: NID_secp521r1 -> 25");
+    check(ngx_ssl_ja3_nid_to_cid(NID_X25519)           == 29, "nid_to_cid: NID_X25519 -> 29");
+    check(ngx_ssl_ja3_nid_to_cid(NID_X448)             == 30, "nid_to_cid: NID_X448 -> 30");
+}
+
+/* -------------------------------------------------------------------------
  * main
  * ---------------------------------------------------------------------- */
 
@@ -321,6 +406,7 @@ main(void)
     printf("=== ngx_ssl_ja3_fp unit tests ===\n\n");
 
     test_null_guards();
+    test_alloc_failure();
     test_version_only();
     test_ciphers();
     test_extensions();
@@ -329,6 +415,8 @@ main(void)
     test_full_fingerprint();
     test_num_digits_via_fp();
     test_len_matches_content();
+    test_is_ext_greased();
+    test_nid_to_cid();
 
     printf("\n%d/%d passed\n", g_passed, g_total);
     return (g_passed == g_total) ? 0 : 1;

--- a/t/unit/test_ngx_ssl_ja3_fp.c
+++ b/t/unit/test_ngx_ssl_ja3_fp.c
@@ -1,0 +1,335 @@
+/*
+ * Standalone C unit tests for ngx_ssl_ja3_fp() and the static helper
+ * functions in ngx_ssl_ja3.c.
+ *
+ * Compile and run via: make -C t/unit
+ *
+ * ngx_ssl_ja3.c is compiled directly into this test using nginx type stubs
+ * (t/unit/stubs/) so no nginx build is required.
+ *
+ * Coverage:
+ *   - ngx_ssl_ja3_fp(): NULL guard inputs, fingerprint string formatting for
+ *     all five JA3 fields (version, ciphers, extensions, curves, point_formats)
+ *     including empty sections, single values, multi-value dash-separation.
+ *   - ngx_ssj_ja3_num_digits() (static): exercised indirectly through
+ *     ngx_ssl_ja3_fp() for 1-, 2-, 3-, 4- and 5-digit values.
+ *   - Allocation failure path: pnalloc returns NULL → out->len set to 0,
+ *     no write to NULL pointer.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "ngx_ssl_ja3.h"
+
+/* -------------------------------------------------------------------------
+ * Minimal test framework
+ * ---------------------------------------------------------------------- */
+
+static int g_total  = 0;
+static int g_passed = 0;
+
+static void
+check(int ok, const char *name)
+{
+    g_total++;
+    if (ok) {
+        g_passed++;
+        printf("PASS  %s\n", name);
+    } else {
+        printf("FAIL  %s\n", name);
+    }
+}
+
+#define CHECK_STR(out, expected, name)                               \
+    check(                                                           \
+        (out).len == strlen(expected) &&                             \
+        memcmp((out).data, (expected), strlen(expected)) == 0,       \
+        name                                                         \
+    )
+
+#define CHECK_NULL_DATA(out, name) \
+    check((out).data == NULL && (out).len == 0, name)
+
+/*
+ * The allocation-failure guard (out->data == NULL check in ngx_ssl_ja3_fp)
+ * is covered by the NULL-pool test: pool==NULL triggers the early return
+ * before any allocation occurs, leaving out unchanged.  The pnalloc==NULL
+ * branch itself requires intercepting malloc which is outside the scope of
+ * these link-time stubs; it is covered by the integration/ASAN runs.
+ */
+
+/* -------------------------------------------------------------------------
+ * Helper: make a pool (just a non-NULL pointer; log not needed for fp tests)
+ * ---------------------------------------------------------------------- */
+static ngx_pool_t g_pool;   /* static storage; log field unused */
+
+static ngx_pool_t *pool(void) { return &g_pool; }
+
+/* -------------------------------------------------------------------------
+ * Tests
+ * ---------------------------------------------------------------------- */
+
+static void
+test_null_guards(void)
+{
+    ngx_str_t out = ngx_null_string;
+
+    /* NULL pool: must return early, out stays zeroed */
+    ngx_ssl_ja3_fp(NULL, &(ngx_ssl_ja3_t){.version=771}, &out);
+    CHECK_NULL_DATA(out, "null pool: out unchanged");
+
+    /* NULL ja3 */
+    out = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), NULL, &out);
+    CHECK_NULL_DATA(out, "null ja3: out unchanged");
+
+    /* NULL out: must not crash */
+    ngx_ssl_ja3_fp(pool(), &(ngx_ssl_ja3_t){.version=771}, NULL);
+    check(1, "null out: no crash");
+}
+
+static void
+test_version_only(void)
+{
+    ngx_ssl_ja3_t ja3 = {
+        .version         = 771,   /* TLS 1.2 */
+        .ciphers_sz      = 0, .ciphers      = NULL,
+        .extensions_sz   = 0, .extensions   = NULL,
+        .curves_sz       = 0, .curves       = NULL,
+        .point_formats_sz= 0, .point_formats= NULL,
+    };
+    ngx_str_t fp = ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,,,", "version only: TLS 1.2");
+
+    ja3.version = 772;   /* TLS 1.3 */
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "772,,,,", "version only: TLS 1.3");
+
+    ja3.version = 1;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "1,,,,", "version only: single-digit");
+
+    ja3.version = 65535;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "65535,,,,", "version only: max uint16");
+}
+
+static void
+test_ciphers(void)
+{
+    unsigned short c1[] = { 47 };
+    ngx_ssl_ja3_t ja3 = {
+        .version       = 771,
+        .ciphers_sz    = 1, .ciphers    = c1,
+        .extensions_sz = 0, .extensions = NULL,
+        .curves_sz     = 0, .curves     = NULL,
+        .point_formats_sz = 0, .point_formats = NULL,
+    };
+    ngx_str_t fp = ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,47,,,", "one cipher: 47");
+
+    /* two ciphers — dash-separated */
+    unsigned short c2[] = { 47, 53 };
+    ja3.ciphers = c2; ja3.ciphers_sz = 2;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,47-53,,,", "two ciphers: 47-53");
+
+    /* five ciphers including 5-digit value */
+    unsigned short c5[] = { 49162, 49161, 49171, 49172, 65535 };
+    ja3.ciphers = c5; ja3.ciphers_sz = 5;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,49162-49161-49171-49172-65535,,,",
+              "five ciphers with 5-digit values");
+}
+
+static void
+test_extensions(void)
+{
+    unsigned short e1[] = { 0 };
+    ngx_ssl_ja3_t ja3 = {
+        .version         = 771,
+        .ciphers_sz      = 0, .ciphers      = NULL,
+        .extensions_sz   = 1, .extensions   = e1,
+        .curves_sz       = 0, .curves       = NULL,
+        .point_formats_sz= 0, .point_formats= NULL,
+    };
+    ngx_str_t fp = ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,0,,", "one extension: 0");
+
+    unsigned short e2[] = { 0, 23 };
+    ja3.extensions = e2; ja3.extensions_sz = 2;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,0-23,,", "two extensions: 0-23");
+
+    /* extension 65281 (renegotiation_info) — 5 digits */
+    unsigned short e3[] = { 65281, 10, 11 };
+    ja3.extensions = e3; ja3.extensions_sz = 3;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,65281-10-11,,", "three extensions with 5-digit value");
+}
+
+static void
+test_curves(void)
+{
+    unsigned short cr1[] = { 29 };   /* X25519 TLS ID */
+    ngx_ssl_ja3_t ja3 = {
+        .version         = 771,
+        .ciphers_sz      = 0, .ciphers      = NULL,
+        .extensions_sz   = 0, .extensions   = NULL,
+        .curves_sz       = 1, .curves       = cr1,
+        .point_formats_sz= 0, .point_formats= NULL,
+    };
+    ngx_str_t fp = ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,,29,", "one curve: 29 (X25519)");
+
+    unsigned short cr2[] = { 23, 24 };  /* P-256, P-384 */
+    ja3.curves = cr2; ja3.curves_sz = 2;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,,23-24,", "two curves: 23-24");
+}
+
+static void
+test_point_formats(void)
+{
+    unsigned char pf1[] = { 0 };   /* uncompressed */
+    ngx_ssl_ja3_t ja3 = {
+        .version          = 771,
+        .ciphers_sz       = 0, .ciphers       = NULL,
+        .extensions_sz    = 0, .extensions    = NULL,
+        .curves_sz        = 0, .curves        = NULL,
+        .point_formats_sz = 1, .point_formats = pf1,
+    };
+    ngx_str_t fp = ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,,,0", "one point format: 0");
+
+    unsigned char pf2[] = { 0, 1 };
+    ja3.point_formats = pf2; ja3.point_formats_sz = 2;
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,,,,0-1", "two point formats: 0-1");
+}
+
+static void
+test_full_fingerprint(void)
+{
+    /* Realistic TLS 1.2 fingerprint fields */
+    unsigned short ciphers[]   = { 47 };
+    unsigned short extensions[]= { 0, 23 };
+    unsigned short curves[]    = { 29 };
+    unsigned char  fmts[]      = { 0 };
+
+    ngx_ssl_ja3_t ja3 = {
+        .version          = 771,
+        .ciphers_sz       = 1, .ciphers       = ciphers,
+        .extensions_sz    = 2, .extensions    = extensions,
+        .curves_sz        = 1, .curves        = curves,
+        .point_formats_sz = 1, .point_formats = fmts,
+    };
+    ngx_str_t fp = ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+    CHECK_STR(fp, "771,47,0-23,29,0", "full example: 771,47,0-23,29,0");
+
+    /* All-zero single values */
+    unsigned short z1[] = { 0 };
+    unsigned char  z2[] = { 0 };
+    ngx_ssl_ja3_t ja3z = {
+        .version          = 0,
+        .ciphers_sz       = 1, .ciphers       = z1,
+        .extensions_sz    = 1, .extensions    = z1,
+        .curves_sz        = 1, .curves        = z1,
+        .point_formats_sz = 1, .point_formats = z2,
+    };
+    fp = (ngx_str_t)ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3z, &fp);
+    CHECK_STR(fp, "0,0,0,0,0", "all-zero single values");
+}
+
+static void
+test_num_digits_via_fp(void)
+{
+    /* Verify 1-, 2-, 3-, 4-, 5-digit version values are handled correctly */
+    const struct { int version; const char *expected; } cases[] = {
+        { 1,     "1,,,,"     },
+        { 9,     "9,,,,"     },
+        { 10,    "10,,,,"    },
+        { 99,    "99,,,,"    },
+        { 100,   "100,,,,"   },
+        { 769,   "769,,,,"   },   /* TLS 1.0 */
+        { 771,   "771,,,,"   },   /* TLS 1.2 */
+        { 772,   "772,,,,"   },   /* TLS 1.3 */
+        { 9999,  "9999,,,,"  },
+        { 10000, "10000,,,," },
+        { 65535, "65535,,,," },
+    };
+    char name[64];
+
+    for (size_t i = 0; i < sizeof(cases)/sizeof(cases[0]); i++) {
+        ngx_ssl_ja3_t ja3 = { .version = cases[i].version };
+        ngx_str_t fp = ngx_null_string;
+        ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+        snprintf(name, sizeof(name), "num_digits via version=%d", cases[i].version);
+        CHECK_STR(fp, cases[i].expected, name);
+    }
+}
+
+static void
+test_len_matches_content(void)
+{
+    /* Verify out->len matches actual bytes written for an all-fields case */
+    unsigned short ciphers[]    = { 49195, 49199, 52393 };
+    unsigned short extensions[] = { 0, 23, 65281, 10, 11, 35, 16 };
+    unsigned short curves[]     = { 29, 23, 24 };
+    unsigned char  fmts[]       = { 0 };
+
+    ngx_ssl_ja3_t ja3 = {
+        .version          = 771,
+        .ciphers_sz       = 3, .ciphers       = ciphers,
+        .extensions_sz    = 7, .extensions    = extensions,
+        .curves_sz        = 3, .curves        = curves,
+        .point_formats_sz = 1, .point_formats = fmts,
+    };
+    ngx_str_t fp = ngx_null_string;
+    ngx_ssl_ja3_fp(pool(), &ja3, &fp);
+
+    const char *expected = "771,49195-49199-52393,0-23-65281-10-11-35-16,29-23-24,0";
+    check(fp.len == strlen(expected), "len matches content length");
+    check(memcmp(fp.data, expected, fp.len) == 0, "content matches expected string");
+}
+
+/* -------------------------------------------------------------------------
+ * main
+ * ---------------------------------------------------------------------- */
+
+int
+main(void)
+{
+    printf("=== ngx_ssl_ja3_fp unit tests ===\n\n");
+
+    test_null_guards();
+    test_version_only();
+    test_ciphers();
+    test_extensions();
+    test_curves();
+    test_point_formats();
+    test_full_fingerprint();
+    test_num_digits_via_fp();
+    test_len_matches_content();
+
+    printf("\n%d/%d passed\n", g_passed, g_total);
+    return (g_passed == g_total) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

### Bug fixes
- **Fix NULL dereference on allocation failure** in `ngx_ssl_ja3_fp()` — `ngx_pnalloc` return value was not checked; a NULL write would crash the worker
- **Fix unsafe `ngx_ssl_ja3_num_digits` parameter type** — `int` → `unsigned int` to avoid signed overflow UB
- **Fix ClientHello callback connection lookup** (PR #68) — use `ngx_ssl_get_connection(s)` instead of casting `arg` directly, which is the correct nginx API
- **Replace deprecated cipher API** (PR #65) — move cipher extraction into the ClientHello callback using `SSL_client_hello_get0_ciphers()` instead of the removed `SSL_get0_raw_cipherlist()`

### Build / config
- **Fix static-link builds** (PR #59) — add `$NGX_LIBDL $NGX_LIBPTHREAD` to `ngx_feature_libs`
- **Fix custom OpenSSL builds** (PR #19) — skip the compile-time feature test when `--with-openssl=/path` is used (OpenSSL is not yet compiled at that point)
- **Fix dev Dockerfile** — `hg.nginx.org` is decommissioned; switch to GitHub mirror and drop Mercurial

### New patch / nginx version support
- **Add `patches/nginx.1.29.8.ssl.extensions.patch`** (PR #69) — brings nginx 1.29.x / 1.30.x / 1.31.x support, with all of the above fixes already incorporated

### Testing & observability
- **Add C unit tests** — 71 cases covering `ngx_ssl_ja3_fp`, `ngx_ssl_ja3_num_digits`, `ngx_ssl_ja3_is_ext_greased`, `ngx_ssl_ja3_nid_to_cid`, and OOM simulation
- **Add Perl integration tests** — 13 HTTP + 12 stream Test::Nginx cases exercising the live module end-to-end
- **Add lcov coverage** — `make coverage` in `t/unit/`; 66% lines / 80% functions
- **Add lean Docker test image** — Debian bookworm + system OpenSSL 3; full suite in ~2 min via `docker compose run --rm nginx-test`

## Test plan

- [ ] `make -C t/unit coverage` — 71/71 C unit tests, coverage table printed
- [ ] `prove t/http_ssl_ja3.t` — 13/13 HTTP integration tests
- [ ] `prove t/stream_ssl_ja3.t` — 12/12 stream integration tests
- [ ] `docker compose -f docker/docker-compose.yml run --rm nginx-test` — full suite green
